### PR TITLE
Route params feature added for more fine tuned results

### DIFF
--- a/routes/en.js
+++ b/routes/en.js
@@ -20,9 +20,11 @@ router.get("/", function (req, res) {
   res.header("Strict-Transport-Security", "max-age=63072000");
   res.setHeader("Content-Type", "application/json");
 
+  const partOfSpeech = req.query.type;
+
   axios({
     method: "GET",
-    url: "https://randomword.com/",
+    url: partOfSpeech ? `https://randomword.com/${partOfSpeech}` : `https://randomword.com`,
     headers: {
       "User-Agent": rua,
     },


### PR DESCRIPTION
Users of this random word api can now pass in a list of type params to fine tune their search results.
Say the user only wanted a random word of any part of speech, the endpoint can be hit as normal: /word. This is extended to also provide users the option of specifically accepting: noun, a sentence, a question, an idiom, verb, letter, paragraph, a vocabulary response, affirmations and 1,2,3 word quotes. 
An example of this would be: 
_https://random-words-api.vercel.app/word?type=noun_
_https://random-words-api.vercel.app/word?type=verb_
_https://random-words-api.vercel.app/word?type=adjective_
_https://random-words-api.vercel.app/word?type=question_
and so forth. Users can visit randomword.com and use the top nav links to determine all available types.